### PR TITLE
feat(renovate): disable `^@ethersproject` packages upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
             "groupName": "Dependencies"
         },
         {
-            "matchPackagePatterns": ["^@angular/", "^ngx", "^@ngrx"],
+            "matchPackagePatterns": ["^@angular/", "^ngx", "^@ngrx", "^@ethersproject"],
             "enabled": false
         }
     ]


### PR DESCRIPTION
A collective decision has been made to exclude all packages associated with an `ethers` from automatic updates. The team will control the package versioning itself, as it requires synchronization between all repositories. Packages starting with `ethersproject` are therefore also excluded from automatic updates.