### PR TITLE
ci: publish GitHub packages release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         run:  node common/scripts/install-run-rush.js version --bump --target-branch master
 
       - name: Publish packages
-        run: node common/scripts/install-run-rush.js publish --apply --publish --include-all
+        run: node common/scripts/install-run-rush.js publish --apply --publish --include-all  --target-branch master
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will allow Rush to publish Github tag releases for packages.