### PR TITLE
Task/remove dist from gh release

### DIFF
--- a/common/changes/@energyweb/semantic-release-config/task-remove-dist-from-gh-release_2022-02-25-11-48.json
+++ b/common/changes/@energyweb/semantic-release-config/task-remove-dist-from-gh-release_2022-02-25-11-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@energyweb/semantic-release-config",
+      "comment": "remove `dist` dir from GH release assets",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@energyweb/semantic-release-config"
+}

--- a/packages/semantic-release-config/index.js
+++ b/packages/semantic-release-config/index.js
@@ -33,9 +33,7 @@ module.exports = {
       },
     ],
     "@semantic-release/npm",
-    ["@semantic-release/github", {
-      assets: ["dist/**"]
-    }],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
Github release tag with dist folder as a asset: https://github.com/energywebfoundation/iam-client-lib/releases/tag/untagged-cfaac38585e01ff14db5.