### PR TITLE
Skip release notes in semantic commit

### DIFF
--- a/common/changes/@energyweb/semantic-release-config/rm_release_notes_from_semantic_commit_2023-07-20-13-05.json
+++ b/common/changes/@energyweb/semantic-release-config/rm_release_notes_from_semantic_commit_2023-07-20-13-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@energyweb/semantic-release-config",
+      "comment": "skip release notes from commit message",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@energyweb/semantic-release-config"
+}

--- a/packages/semantic-release-config/index.js
+++ b/packages/semantic-release-config/index.js
@@ -51,6 +51,7 @@ module.exports = {
       "@semantic-release/git",
       {
         assets: ["package.json", "docs/CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       },
     ],
   ],


### PR DESCRIPTION
Semantic release creates commits with release notes, which is only makes more difficult reading of history and requires solving issues like this https://github.com/energywebfoundation/iam-client-lib/actions/runs/5609890929/jobs/10264165871?pr=712